### PR TITLE
Deprecate number argument in path function

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ Installs a mouse helper on the page, making the pointer visible. Gets executed i
 
 Gets a random point on the browser window.
 
-#### `path(start: Vector, end: Vector | BoundingBox, options?: number | PathOptions): Vector[] | TimedVector[]`
+#### `path(start: Vector, end: Vector | BoundingBox, options?: PathOptions): Vector[] | TimedVector[]`
 
 Generates a set of points for mouse movement between two coordinates.
 
 - **start:** Starting point of the movement.
 - **end:** Ending point (or bounding box) of the movement.
-- **options (optional):** Additional options for generating the path. Can also be a number which will set `spreadOverride`.
+- **options (optional):** Additional options for generating the path.
     - `spreadOverride (number):` Override the spread of the generated path.
     - `moveSpeed (number):` Speed of mouse movement. Default is random.
     - `useTimestamps (boolean):` Generate timestamps for each point based on the trapezoidal rule.

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -280,13 +280,9 @@ export function path (
   end: Vector | BoundingBox,
   /**
    * Additional options for generating the path.
-   * Can also be a number which will set `spreadOverride`.
    */
-  // TODO: remove number arg in next major version change, fine to just allow `spreadOverride` in object.
-  options?: number | PathOptions): Vector[] | TimedVector[] {
-  const optionsResolved: PathOptions = typeof options === 'number'
-    ? { spreadOverride: options }
-    : { ...options }
+  options?: PathOptions): Vector[] | TimedVector[] {
+  const optionsResolved: PathOptions = { ...options }
 
   const DEFAULT_WIDTH = 100
   const MIN_STEPS = 25


### PR DESCRIPTION
The `path` function in `src/spoof.ts` has been refactored to only accept `PathOptions` (or `undefined`) for its `options` parameter, removing the previously supported `number` type (which was interpreted as `spreadOverride`).

Key changes:
- Updated `path` function signature in `src/spoof.ts`.
- Removed `typeof options === 'number'` conditional logic in `src/spoof.ts`.
- Removed the TODO comment regarding this change.
- Updated `path` function documentation in `README.md`.
- Verified changes manually; environment limitations prevented running automated tests.

---
*PR created automatically by Jules for task [8150296295159445615](https://jules.google.com/task/8150296295159445615) started by @phanthai12*